### PR TITLE
Compatibility with transformers-0.7 series

### DIFF
--- a/errors.cabal
+++ b/errors.cabal
@@ -27,7 +27,7 @@ Library
         base                >= 4.7   && < 5   ,
         exceptions          >= 0.6   && < 0.11,
         text                            < 2.1 ,
-        transformers        >= 0.2   && < 0.6 ,
+        transformers        >= 0.2   && < 0.7 ,
         transformers-compat >= 0.4   && < 0.8
     if impl(ghc <= 7.6.3)
         Build-Depends:


### PR DESCRIPTION
Tested using

    cabal build --constraint='transformers>=0.6' -w ghc-9.2.2
